### PR TITLE
Fix C++ compilation

### DIFF
--- a/cpp/BFS/BFS.cpp
+++ b/cpp/BFS/BFS.cpp
@@ -7,6 +7,7 @@
 
 #include <stdio.h>
 #include <algorithm>
+#include <cstring>
 #include "BFS.hpp"
 
 BFS::BFS(int width, int height): width(width), height(height) {

--- a/cpp/BFS/main.cpp
+++ b/cpp/BFS/main.cpp
@@ -21,7 +21,7 @@ void test() {
 
     auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    std::cout << "Time: " << elapsed.count();
+    std::cout << "Time: " << elapsed.count() << std::endl;
 }
 
 int main(int argc, const char * argv[]) {


### PR DESCRIPTION
Without `<cstring>`, `memset` is unavailable on my both Linux and Windows machines

```
BFS.cpp: In member function ‘void BFS::generateWalls()’:
BFS.cpp:20:5: error: ‘memset’ was not declared in this scope
   20 |     memset(walls, false, width * height * sizeof(bool));
      |     ^~~~~~
BFS.cpp:11:1: note: ‘memset’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
   10 | #include "BFS.hpp"
  +++ |+#include <cstring>
```

Also endl in the output